### PR TITLE
TU-T4346 fixed configurable panelWidth

### DIFF
--- a/src/app/components/autocomplete-chips/autocomplete-chips.component.html
+++ b/src/app/components/autocomplete-chips/autocomplete-chips.component.html
@@ -81,7 +81,7 @@
       [class]="panelClasses"
       (optionSelected)="optionSelected($event)"
       (closed)="closed()"
-      [panelWidth]="400"
+      [panelWidth]="panelWidth"
       [autoActiveFirstOption]="true">
     <ng-container *ngIf="keyword && allowText">
       <mat-option 


### PR DESCRIPTION
By previous commits made that by default panelWidth is setted is 400. And this variable as @Input value what mean that it can be configurable. But in html template use const value not Input value. What  prevents us from redefining this value